### PR TITLE
Bug on Floor() function and in test of Integer !!!

### DIFF
--- a/BigDecimal/BigDecimal.cs
+++ b/BigDecimal/BigDecimal.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;

--- a/BigDecimal/BigDecimal.cs
+++ b/BigDecimal/BigDecimal.cs
@@ -361,7 +361,14 @@ namespace ExtendedNumerics
 
 			if (Exponent.Equals(other.Exponent)) return Mantissa.Equals(other.Mantissa);
 
-			return GetWholePart().Equals(other.GetWholePart());
+			if (Exponent > other.Exponent)
+			{
+				return (AlignExponent(this, other) == other.Mantissa);
+			}
+			else
+			{
+				return (Mantissa == AlignExponent(other, this));
+			}
 		}
 
 		public Boolean Equals(BigDecimal? other) => Equals(this, other);

--- a/BigDecimal/BigDecimal.cs
+++ b/BigDecimal/BigDecimal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -355,6 +356,15 @@ namespace ExtendedNumerics
 
 		#region Equals
 
+		public bool Equals(BigDecimal other)
+		{
+			if (!Sign.Equals(other.Sign)) return false;
+
+			if (Exponent.Equals(other.Exponent)) return Mantissa.Equals(other.Mantissa);
+
+			return GetWholePart().Equals(other.GetWholePart());
+		}
+
 		public Boolean Equals(BigDecimal? other) => Equals(this, other);
 
 		/// <summary>
@@ -408,6 +418,8 @@ namespace ExtendedNumerics
 		/// <returns>True if the two numbers are equal, up to <paramref name="precision"/>.</returns>
 		public static Boolean Equals(BigDecimal? left, BigDecimal? right, int precision)
 		{
+			Console.WriteLine("Equals");
+
 			if (left == null || right == null)
 			{
 				return (left == null && right == null);
@@ -827,6 +839,8 @@ namespace ExtendedNumerics
 
 		/// <summary>Returns a value that indicates whether a <see cref="BigDecimal"/> value is greater than or equal to another <see cref="BigDecimal"/> value.</summary>
 		public static Boolean operator >=(BigDecimal left, BigDecimal right) => left.Exponent > right.Exponent ? AlignExponent(left, right) >= right.Mantissa : left.Mantissa >= AlignExponent(right, left);
+
+		//public static bool operator ==(BigDecimal left, BigDecimal right) => left.Equals(right);
 
 		#endregion
 

--- a/BigDecimal/BigDecimal.cs
+++ b/BigDecimal/BigDecimal.cs
@@ -418,8 +418,6 @@ namespace ExtendedNumerics
 		/// <returns>True if the two numbers are equal, up to <paramref name="precision"/>.</returns>
 		public static Boolean Equals(BigDecimal? left, BigDecimal? right, int precision)
 		{
-			Console.WriteLine("Equals");
-
 			if (left == null || right == null)
 			{
 				return (left == null && right == null);
@@ -839,8 +837,6 @@ namespace ExtendedNumerics
 
 		/// <summary>Returns a value that indicates whether a <see cref="BigDecimal"/> value is greater than or equal to another <see cref="BigDecimal"/> value.</summary>
 		public static Boolean operator >=(BigDecimal left, BigDecimal right) => left.Exponent > right.Exponent ? AlignExponent(left, right) >= right.Mantissa : left.Mantissa >= AlignExponent(right, left);
-
-		//public static bool operator ==(BigDecimal left, BigDecimal right) => left.Equals(right);
 
 		#endregion
 

--- a/TestBigDecimal/TestBigDecimal.csproj
+++ b/TestBigDecimal/TestBigDecimal.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net45;net46;net472;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net45;net46;net472;net48;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<LangVersion>latest</LangVersion>
 		<AnalysisLevel>latest</AnalysisLevel>

--- a/TestBigDecimal/TestBigDecimalOperations.cs
+++ b/TestBigDecimal/TestBigDecimalOperations.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.Numerics;
 using System.Threading;
@@ -12,7 +13,7 @@ namespace TestBigDecimal
 {
 
 	[TestFixture]
-	[Culture("en-US,ru-RU")]
+	//[Culture("en-US,ru-RU,fr-FR,be-FR")]
 	public class TestBigDecimalOperations
 	{
 		private NumberFormatInfo Format { get { return Thread.CurrentThread.CurrentCulture.NumberFormat; } }
@@ -364,6 +365,7 @@ namespace TestBigDecimal
 		[Test]
 		public void TestFloor003()
 		{
+			BigDecimal.AlwaysNormalize = false;
 			var start = BigDecimal.Parse(TestBigDecimalHelper.PrepareValue("-0.14159265", this.Format));
 			var floor = BigDecimal.Floor(start);
 
@@ -391,6 +393,28 @@ namespace TestBigDecimal
 			float expectedFloor = (float)Math.Floor(start_compare);
 
 			Assert.AreEqual(expectedFloor.ToString(), actualFloor.ToString());
+		}
+
+		[Test]
+		public void TestFloorNegative()
+		{
+			BigDecimal.AlwaysNormalize = false;
+
+			BigDecimal k = new BigDecimal(-1,1); // = -10
+			//Assert.AreEqual(new BigDecimal(-10), k);
+			BigDecimal e1 = BigDecimal.Floor(k);
+			Assert.AreEqual(new BigDecimal(-10), e1);
+			BigDecimal e2 = k.GetWholePart();
+			Assert.AreEqual(new BigDecimal(-10), e2);
+		}
+
+		[Test]
+		public void TestEqualToInt()
+		{
+			BigDecimal.AlwaysNormalize = false;
+
+			BigDecimal n = new BigDecimal(50, -1); // = 5 
+		    Assert.AreEqual(new BigDecimal(5), n);
 		}
 
 		[Test]


### PR DESCRIPTION
Hello,

I discover 2 bugs in `BigDecimal` when using `BigDecimal.AlwaysNormalize = false` 

I have added 2 tests functions in `TestBigDecimalOperations.cs`

```
		[Test]
		public void TestFloorNegative()
		{
			BigDecimal.AlwaysNormalize = false;

			BigDecimal k = new BigDecimal(-1,1); // = -10
			//Assert.AreEqual(new BigDecimal(-10), k);
			BigDecimal e1 = BigDecimal.Floor(k);
			Assert.AreEqual(new BigDecimal(-10), e1);
			BigDecimal e2 = k.GetWholePart();
			Assert.AreEqual(new BigDecimal(-10), e2);
		}
```

and

```
		[Test]
		public void TestEqualToInt()
		{
			BigDecimal.AlwaysNormalize = false;

			BigDecimal n = new BigDecimal(50, -1); // = 5 
		    Assert.AreEqual(new BigDecimal(5), n);
		}
```

I discovered this bug in drawing cumulative graph using `Exp()` function. 

This bug is corrected in adding `Equals()` function in `BigDecimal.cs`

```
		public bool Equals(BigDecimal other)
		{
			if (!Sign.Equals(other.Sign)) return false;

			if (Exponent.Equals(other.Exponent)) return Mantissa.Equals(other.Mantissa);

			return GetWholePart().Equals(other.GetWholePart());
		}
```

This bug occurs because default `Equals` operator compare `BigDecimal` structure value and not `BigDecimal` number.

For previous `Equals()` function, comparing 5.10^0 is not equal to 50.10^-1 ! But mathematically, these 2 numbers are equal !

Caution: I have commented `//[Culture("en-US,ru-RU")]` in `TestBigDecimalOperations.cs` because this produce e lot of error in my PC than run using `fr-FR` culture. 

I regret that all your tests don't use neutral culture when it is possible ! But this is another story !